### PR TITLE
Prepare Finance v3.4.1 loan usage editing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 COMPOSE=docker compose -f tools/docker/docker-compose.yaml
 COMPOSE_PROD=docker compose -f docker/docker-compose.yaml
 IMAGE_REPO?=f1nanc3/finance
-VERSION?=3.4.0
+VERSION?=3.4.1
 PLATFORMS?=linux/amd64,linux/arm64
 
 build:

--- a/README.es.md
+++ b/README.es.md
@@ -14,9 +14,9 @@ Repositorio: [osmelonunez/finance](https://github.com/osmelonunez/finance)
 
 ## Versión Actual
 
-- Versión estable: `3.4.0`
-- Release: `v3.4.0 - Robustez de datos y seguridad de UX`
-- El compose de producción usa imagen fijada en `f1nanc3/finance:3.4.0`
+- Versión estable: `3.4.1`
+- Release: `v3.4.1 - Edición de usos de préstamo`
+- El compose de producción usa imagen fijada en `f1nanc3/finance:3.4.1`
 
 ## Funcionalidades Principales
 
@@ -40,7 +40,7 @@ Repositorio: [osmelonunez/finance](https://github.com/osmelonunez/finance)
   - bancos
 - Préstamos con banco, cantidad, plazo, cuota mensual, descripción, estado y seguimiento de pagos
 - Tipos de préstamo: sin intereses, con intereses e hipotecas con separación de amortización/intereses
-- Seguimiento de uso de préstamo para registrar en qué se gasta el dinero prestado sin contarlo como ingreso mensual
+- Seguimiento editable de usos de préstamo para registrar en qué se gasta el dinero prestado sin contarlo como ingreso mensual
 - Pagos de préstamo registrados desde gastos sin contar la solicitud del préstamo como ingreso
 - Exclusión opcional de préstamos en dashboard y totales de analíticas
 - Pagos aplazados

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Repository: [osmelonunez/finance](https://github.com/osmelonunez/finance)
 
 ## Current Version
 
-- Stable version: `3.4.0`
-- Release: `v3.4.0 - Data Robustness and UX Safety`
-- Production compose image is pinned to `f1nanc3/finance:3.4.0`
+- Stable version: `3.4.1`
+- Release: `v3.4.1 - Loan Usage Editing`
+- Production compose image is pinned to `f1nanc3/finance:3.4.1`
 
 ## Core Features
 
@@ -40,7 +40,7 @@ Repository: [osmelonunez/finance](https://github.com/osmelonunez/finance)
   - banks
 - Loans with bank, amount, term, monthly payment, description, status, and payment tracking
 - Loan types: no interest, interest-bearing loans, and mortgages with principal/interest split
-- Loan usage tracking to record what borrowed money is spent on without counting it as monthly income
+- Editable loan usage tracking to record what borrowed money is spent on without counting it as monthly income
 - Loan payments registered from expenses without counting loan requests as income
 - Optional loan exclusion from dashboard and analytics totals
 - Deferred expenses

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -107,6 +107,20 @@ Validacion:
 - `make up`
 - Pruebas manuales de validacion, formularios, modales, gestion, datos demo y prestamos.
 
+### v3.4.1 - Edicion de usos de prestamo
+
+Estado: preparado para release.
+
+Objetivo: completar la gestion de los usos de prestamo sin introducir cambios de esquema.
+
+Incluye:
+- Edicion en linea de concepto, categoria, fecha, importe y comentario.
+- Acciones consistentes de Editar, Cancelar, Guardar y Eliminar.
+- Validacion backend y actualizacion de los campos de auditoria.
+- Tabla reorganizada con fondo blanco y espacio estable para las acciones.
+- [Notas de release en espanol](docs/v3.4.1-release/notas-v3.4.1.md)
+- [Release notes in English](docs/v3.4.1-release/v3.4.1-release-notes.md)
+
 ## Ideas futuras
 
 Estas ideas no estan comprometidas todavia y pueden moverse segun prioridad.

--- a/backend/app.py
+++ b/backend/app.py
@@ -95,7 +95,7 @@ app = Flask(
     static_url_path="/static"
 )
 app.secret_key = os.environ.get("SECRET_KEY", DEFAULT_SECRET_KEY)
-app.config["APP_VERSION"] = os.environ.get("APP_VERSION", "3.4.0")
+app.config["APP_VERSION"] = os.environ.get("APP_VERSION", "3.4.1")
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -179,7 +179,7 @@ def inject_template_globals():
     lang = get_lang()
     return {
         "current_year": datetime.now().year,
-        "app_version": app.config.get("APP_VERSION", "3.4.0"),
+        "app_version": app.config.get("APP_VERSION", "3.4.1"),
         "current_lang": lang,
         "t": lambda text: t(text, lang),
         "cat_name": lambda name: category_name(name, lang),

--- a/backend/routes/loans.py
+++ b/backend/routes/loans.py
@@ -532,6 +532,78 @@ def loan_usage_delete(id, usage_id):
     return redirect(f"/loans/{id}?tab=usages&usage_page={usage_page}")
 
 
+@loans_bp.route("/loans/<int:id>/usages/<int:usage_id>/update", methods=["POST"])
+def loan_usage_update(id, usage_id):
+    usage_page = _parse_page(request.args.get("usage_page"))
+    error_url = f"/loans/{id}?tab=usages&usage_page={usage_page}&edit_usage={usage_id}"
+
+    concept, concept_error = validate_concept(
+        request.form.get("concept"),
+        MAX_LOAN_USAGE_CONCEPT_LENGTH,
+        "Usage concept",
+    )
+    if concept_error:
+        return redirect(f"{error_url}&error={quote(concept_error)}")
+
+    amount, amount_error = _parse_positive_decimal(request.form.get("amount"), "Amount")
+    if amount_error:
+        return redirect(f"{error_url}&error={quote(amount_error)}")
+
+    date = parse_year_month((request.form.get("date") or "").strip(), None)
+    if not date:
+        return redirect(f"{error_url}&error={quote('Date is required.')}")
+
+    comment, comment_error = validate_text_length(
+        request.form.get("comment"),
+        "Usage comment",
+        MAX_LOAN_USAGE_COMMENT_LENGTH,
+    )
+    if comment_error:
+        return redirect(f"{error_url}&error={quote(comment_error)}")
+
+    category_name = (request.form.get("category") or "").strip()
+    with get_db() as conn:
+        with conn.cursor() as cur:
+            category_id = None
+            if category_name:
+                cur.execute("SELECT id FROM categories WHERE name=%s", (category_name,))
+                category_row = cur.fetchone()
+                category_id = category_row[0] if category_row else None
+            cur.execute(
+                """
+                UPDATE loan_usages
+                SET concept=%s,
+                    amount=%s,
+                    date=%s,
+                    category_id=%s,
+                    comment=%s,
+                    updated_at=NOW(),
+                    updated_by=%s
+                WHERE id=%s AND loan_id=%s
+                """,
+                (
+                    concept,
+                    amount,
+                    date.strftime("%Y-%m"),
+                    category_id,
+                    comment,
+                    session.get("user_name"),
+                    usage_id,
+                    id,
+                ),
+            )
+            updated = cur.rowcount
+            conn.commit()
+            logger.info(
+                "loan_usage_update user=%s loan_id=%s usage_id=%s updated=%s",
+                session.get("user_name"),
+                id,
+                usage_id,
+                updated,
+            )
+    return redirect(f"/loans/{id}?tab=usages&usage_page={usage_page}")
+
+
 @loans_bp.route("/loans/<int:id>/status", methods=["POST"])
 def loan_status(id):
     status = (request.form.get("status") or "").strip()

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,7 +1,9 @@
 services:
   finance:
-    image: f1nanc3/finance:3.4.0
+    image: f1nanc3/finance:3.4.1
     container_name: finance
+    ports:
+      - "5000:5000"
     environment:
       # Runtime mode (development/production).
       APP_ENV: production

--- a/docs/v3.4.1-release/notas-v3.4.1.md
+++ b/docs/v3.4.1-release/notas-v3.4.1.md
@@ -1,0 +1,35 @@
+# v3.4.1 - Edición de usos de préstamo
+
+## Resumen
+
+Esta versión patch completa la gestión de los usos registrados dentro de un préstamo. Los usos ahora se pueden editar directamente desde el historial con el mismo patrón de acciones utilizado en cuentas y tarjetas.
+
+## Cambios
+
+- Botón **Editar** para cada uso de préstamo.
+- Edición de concepto, categoría, fecha, importe y comentario.
+- Acciones **Cancelar**, **Guardar** y **Eliminar** visibles durante la edición.
+- Conservación de la página activa después de guardar o eliminar.
+- Validaciones de concepto, importe, fecha y comentario en backend.
+- Actualización de `updated_at` y `updated_by` al guardar.
+- Registro estructurado del evento `loan_usage_update`.
+- Columnas reorganizadas como Concepto, Categoría, Fecha, Importe y Comentario.
+- Fondo blanco para los registros y ancho reservado para las acciones.
+
+## Compatibilidad
+
+- No requiere una migración de base de datos.
+- No modifica los datos existentes.
+- Mantiene las rutas y el comportamiento previo de creación y eliminación.
+
+## Despliegue
+
+- Imagen: `f1nanc3/finance:3.4.1`
+- Tag Git previsto: `v3.4.1`
+
+## Validación
+
+- Compilación de Python y plantilla Jinja.
+- `git diff --check`.
+- Construcción y arranque del entorno Docker de desarrollo.
+- Comprobación de conexión a la base de datos y arranque de Gunicorn.

--- a/docs/v3.4.1-release/v3.4.1-release-notes.md
+++ b/docs/v3.4.1-release/v3.4.1-release-notes.md
@@ -1,0 +1,35 @@
+# v3.4.1 - Loan Usage Editing
+
+## Summary
+
+This patch release completes loan usage management. Usage records can now be edited directly from the history table using the same action pattern as accounts and cards.
+
+## Changes
+
+- Added an **Edit** button to each loan usage record.
+- Added editing for concept, category, date, amount, and comment.
+- Added **Cancel**, **Save**, and **Delete** actions while editing.
+- Preserved the active page after saving or deleting.
+- Added backend validation for concept, amount, date, and comment.
+- Updated `updated_at` and `updated_by` when saving.
+- Added structured `loan_usage_update` event logging.
+- Reordered columns to Concept, Category, Date, Amount, and Comment.
+- Added white record backgrounds and stable space for row actions.
+
+## Compatibility
+
+- No database migration is required.
+- Existing data is not modified.
+- Existing create and delete routes remain compatible.
+
+## Deployment
+
+- Image: `f1nanc3/finance:3.4.1`
+- Planned Git tag: `v3.4.1`
+
+## Validation
+
+- Python and Jinja template compilation.
+- `git diff --check`.
+- Development Docker image build and startup.
+- Database connection and Gunicorn startup checks.

--- a/frontend/templates/loan_detail.html
+++ b/frontend/templates/loan_detail.html
@@ -184,6 +184,41 @@
     .loan-usage-form:has(.is-invalid) .loan-usage-submit {
         padding-top: 1.5rem;
     }
+    .loan-usage-row > td,
+    .loan-usage-row .loan-usage-field:disabled {
+        background-color: #fff;
+    }
+    .loan-usage-row .loan-usage-field:disabled {
+        opacity: 1;
+    }
+    .loan-usage-date-col,
+    .loan-usage-amount-col {
+        width: 125px;
+        min-width: 125px;
+    }
+    .loan-usage-concept-col {
+        width: 190px;
+        min-width: 190px;
+    }
+    .loan-usage-category-col {
+        width: 160px;
+        min-width: 160px;
+    }
+    .loan-usage-comment-col {
+        width: 250px;
+        min-width: 250px;
+    }
+    .loan-usage-actions-col {
+        width: 270px;
+        min-width: 270px;
+        white-space: nowrap;
+    }
+    .loan-usage-row .loan-usage-category:disabled {
+        appearance: none;
+        -webkit-appearance: none;
+        background-image: none;
+        padding-right: 0.5rem;
+    }
     .audit-strip {
         border-top: 1px solid #e3e9f0;
         margin-top: 1rem;
@@ -196,6 +231,7 @@
 {% set paid = loan[9] %}
 {% set available = loan[3] - usage_total %}
 {% set edit_mode = request.args.get('edit') == '1' %}
+{% set edit_usage_id = request.args.get('edit_usage')|int if request.args.get('edit_usage') else none %}
 {% set selected_loan_type = loan[16] if loan[16] else ('mortgage' if loan[12] else 'standard') %}
 {% set is_interest_bearing = selected_loan_type in ['interest', 'mortgage'] %}
 {% set total_to_repay = loan[17] if loan[17] is not none else loan[3] %}
@@ -556,26 +592,47 @@
         <table class="table payments-table align-middle mb-0">
             <thead>
             <tr>
-                <th>{{ t('Date') }}</th>
-                <th>{{ t('Concept') }}</th>
-                <th>{{ t('Category') }}</th>
-                <th>{{ t('Comment') }}</th>
-                <th class="text-end">{{ t('Amount') }}</th>
-                <th></th>
+                <th class="loan-usage-concept-col">{{ t('Concept') }}</th>
+                <th class="loan-usage-category-col">{{ t('Category') }}</th>
+                <th class="loan-usage-date-col">{{ t('Date') }}</th>
+                <th class="text-end loan-usage-amount-col">{{ t('Amount') }}</th>
+                <th class="loan-usage-comment-col">{{ t('Comment') }}</th>
+                <th class="loan-usage-actions-col"></th>
             </tr>
             </thead>
             <tbody>
             {% for usage in usages %}
-            <tr>
-                <td>{{ usage[3] }}</td>
-                <td>{{ usage[1] }}</td>
-                <td>{{ t(usage[4]) if usage[4] else '-' }}</td>
-                <td>{{ usage[5] or '-' }}</td>
-                <td class="text-end">{{ "%.2f"|format(usage[2]) }}</td>
-                <td class="text-end">
+            {% set usage_editing = edit_usage_id == usage[0] %}
+            {% set usage_form_id = 'usage-edit-' ~ usage[0] %}
+            <tr class="loan-usage-row">
+                <td class="loan-usage-concept-col">
+                    <input class="form-control form-control-sm loan-usage-field" form="{{ usage_form_id }}" name="concept" value="{{ usage[1] }}" data-original="{{ usage[1] }}" data-maxlength="40" required {{ '' if usage_editing else 'disabled' }}>
+                </td>
+                <td class="loan-usage-category-col">
+                    <select class="form-select form-select-sm loan-usage-field loan-usage-category" form="{{ usage_form_id }}" name="category" data-original="{{ usage[4] or '' }}" {{ '' if usage_editing else 'disabled' }}>
+                        <option value="">{{ t('Select') }}</option>
+                        {% for category in categories %}
+                        <option value="{{ category }}" {{ 'selected' if usage[4] == category else '' }}>{{ t(category) }}</option>
+                        {% endfor %}
+                    </select>
+                </td>
+                <td class="loan-usage-date-col">
+                    <input class="form-control form-control-sm loan-usage-field" form="{{ usage_form_id }}" type="month" name="date" value="{{ usage[3] }}" data-original="{{ usage[3] }}" required {{ '' if usage_editing else 'disabled' }}>
+                </td>
+                <td class="loan-usage-amount-col">
+                    <input class="form-control form-control-sm text-end loan-usage-field" form="{{ usage_form_id }}" type="number" step="0.01" min="0.01" name="amount" value="{{ '%.2f'|format(usage[2]) }}" data-original="{{ '%.2f'|format(usage[2]) }}" required {{ '' if usage_editing else 'disabled' }}>
+                </td>
+                <td class="loan-usage-comment-col">
+                    <input class="form-control form-control-sm loan-usage-field" form="{{ usage_form_id }}" name="comment" value="{{ usage[5] or '' }}" data-original="{{ usage[5] or '' }}" maxlength="500" {{ '' if usage_editing else 'disabled' }}>
+                </td>
+                <td class="text-end loan-usage-actions-col">
+                    <form id="{{ usage_form_id }}" method="post" action="/loans/{{ loan[0] }}/usages/{{ usage[0] }}/update?usage_page={{ usage_page }}"></form>
+                    <button type="button" class="btn btn-sm btn-outline-secondary loan-usage-edit-btn {{ 'd-none' if usage_editing else '' }}">{{ t('Edit') }}</button>
+                    <button type="button" class="btn btn-sm btn-light loan-usage-cancel-btn {{ '' if usage_editing else 'd-none' }}">{{ t('Cancel') }}</button>
+                    <button type="submit" form="{{ usage_form_id }}" class="btn btn-sm btn-success loan-usage-save-btn {{ '' if usage_editing else 'd-none' }}">{{ t('Save') }}</button>
                     <button
                         type="button"
-                        class="btn btn-sm btn-outline-danger"
+                        class="btn btn-sm btn-outline-danger loan-usage-delete-btn {{ '' if usage_editing else 'd-none' }}"
                         data-bs-toggle="modal"
                         data-bs-target="#deleteUsageModal"
                         data-delete-url="/loans/{{ loan[0] }}/usages/{{ usage[0] }}/delete?usage_page={{ usage_page }}"
@@ -876,6 +933,32 @@ document.addEventListener('DOMContentLoaded', function () {
     calculationModeInputs.forEach((input) => input.addEventListener('change', refreshCalculationMode));
     refreshLoanTypeFields();
     refreshEstimatedInterest();
+
+    function setUsageEditMode(row, on) {
+        const fields = row.querySelectorAll('.loan-usage-field');
+        fields.forEach((field) => { field.disabled = !on; });
+        row.querySelector('.loan-usage-edit-btn')?.classList.toggle('d-none', on);
+        row.querySelector('.loan-usage-cancel-btn')?.classList.toggle('d-none', !on);
+        row.querySelector('.loan-usage-save-btn')?.classList.toggle('d-none', !on);
+        row.querySelector('.loan-usage-delete-btn')?.classList.toggle('d-none', !on);
+        if (on && fields.length) fields[0].focus();
+    }
+
+    document.addEventListener('click', function (event) {
+        const editButton = event.target.closest('.loan-usage-edit-btn');
+        if (editButton) {
+            document.querySelectorAll('.loan-usage-row').forEach((row) => setUsageEditMode(row, row === editButton.closest('tr')));
+            return;
+        }
+        const cancelButton = event.target.closest('.loan-usage-cancel-btn');
+        if (cancelButton) {
+            const row = cancelButton.closest('tr');
+            row.querySelectorAll('.loan-usage-field').forEach((field) => {
+                if (field.dataset.original !== undefined) field.value = field.dataset.original;
+            });
+            setUsageEditMode(row, false);
+        }
+    });
 
     const modal = document.getElementById('deleteUsageModal');
     if (!modal) {


### PR DESCRIPTION
## Summary

- add inline editing for loan usage records
- align loan usage actions and table layout with accounts/cards
- bump application, Docker, and documentation versions to 3.4.1
- add bilingual release notes and expose the production service on port 5000

## Impact

Users can edit the concept, category, date, amount, and comment of an existing loan usage without deleting and recreating it. No database migration is required.

## Validation

- Python compileall inside the development container
- all Jinja templates loaded successfully
- development and production Docker Compose validation
- `/health/live` returned `ok`
- `/health/ready` returned `ready`
- `git diff --check`
