### PR TITLE
Finance 3.6.1: scope account and card names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ COMPOSE=docker compose -f tools/docker/docker-compose.yaml
 COMPOSE_PROD=docker compose -f docker/docker-compose.yaml
 COMPOSE_TEST=docker compose -p finance-tests -f tools/docker/docker-compose.test.yaml
 IMAGE_REPO?=f1nanc3/finance
-VERSION?=3.6.0
+VERSION?=3.6.1
 PLATFORMS?=linux/amd64,linux/arm64
 
 build:

--- a/README.es.md
+++ b/README.es.md
@@ -14,9 +14,9 @@ Repositorio: [osmelonunez/finance](https://github.com/osmelonunez/finance)
 
 ## Versión Actual
 
-- Versión actual: `3.6.0`
-- Release: `v3.6.0 - Banca e integración de préstamos`
-- El compose de producción está preparado para `f1nanc3/finance:3.6.0`
+- Versión actual: `3.6.1`
+- Release: `v3.6.1 - Nombres de cuentas y tarjetas por contexto`
+- El compose de producción está preparado para `f1nanc3/finance:3.6.1`
 
 ## Funcionalidades Principales
 
@@ -46,6 +46,7 @@ Repositorio: [osmelonunez/finance](https://github.com/osmelonunez/finance)
 - El gasto bancario incluye los pagos de préstamos (capital e intereses); los usos del capital son informativos y no se consideran gasto propio ni saldo disponible
 - Filtros de gastos específicos por banco, cuenta y tarjeta
 - Las cuentas requieren un banco y las tarjetas requieren una cuenta; no pueden eliminarse mientras tengan datos relacionados
+- Los nombres de cuenta pueden repetirse entre bancos distintos; los nombres de tarjeta pueden repetirse porque las tarjetas se identifican por ID
 - Formato monetario y numérico adaptado al idioma en toda la aplicación
 - Préstamos con banco, cantidad, plazo, cuota mensual, descripción, estado y seguimiento de pagos
 - Tipos de préstamo: sin intereses, con intereses e hipotecas con separación de amortización/intereses

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Repository: [osmelonunez/finance](https://github.com/osmelonunez/finance)
 
 ## Current Version
 
-- Current version: `3.6.0`
-- Release: `v3.6.0 - Banking and Loan Integration`
-- Production compose is prepared for `f1nanc3/finance:3.6.0`
+- Current version: `3.6.1`
+- Release: `v3.6.1 - Scoped Account and Card Names`
+- Production compose is prepared for `f1nanc3/finance:3.6.1`
 
 ## Core Features
 
@@ -46,6 +46,7 @@ Repository: [osmelonunez/finance](https://github.com/osmelonunez/finance)
 - Bank spending includes loan payments (principal and interest), while loan capital usages remain informational and are not treated as personal spending or available balance
 - Dedicated expense filters for bank, account, and card
 - Accounts require a bank and cards require an account; deletion is blocked while related data exists
+- Account names may be reused across different banks; card names may be repeated because cards are identified by ID
 - Locale-aware number and monetary formatting across the application
 - Loans with bank, amount, term, monthly payment, description, status, and payment tracking
 - Loan types: no interest, interest-bearing loans, and mortgages with principal/interest split

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,6 +153,21 @@ Incluye:
 - [Notas de release en espanol](docs/v3.6-release/notas-v3.6.0.md)
 - [Release notes in English](docs/v3.6-release/v3.6.0-release-notes.md)
 
+### v3.6.1 - Nombres de cuentas y tarjetas por contexto
+
+Estado: preparado.
+
+Objetivo: corregir la unicidad global heredada de los metodos de pago para permitir nombres naturales repetidos cuando pertenecen a entidades padre diferentes.
+
+Incluye:
+- Nombres de cuenta unicos dentro de cada banco, pero reutilizables entre bancos distintos.
+- Nombres de tarjeta sin restriccion de unicidad; la identidad de cada tarjeta depende de su `id`.
+- Migraciones compatibles `016_payment_method_names_scoped_to_parent.sql` y `017_card_names_not_unique.sql`.
+- Mensajes de validacion especificos en español e ingles.
+- Pruebas de integridad para duplicados permitidos y bloqueados.
+- [Notas del hotfix en espanol](docs/v3.6.1-release/notas-v3.6.1.md)
+- [Hotfix notes in English](docs/v3.6.1-release/v3.6.1-release-notes.md)
+
 ## Ideas futuras
 
 Estas ideas no estan comprometidas todavia y pueden moverse segun prioridad.

--- a/backend/app.py
+++ b/backend/app.py
@@ -95,7 +95,7 @@ app = Flask(
     static_url_path="/static"
 )
 app.secret_key = os.environ.get("SECRET_KEY", DEFAULT_SECRET_KEY)
-app.config["APP_VERSION"] = os.environ.get("APP_VERSION", "3.6.0")
+app.config["APP_VERSION"] = os.environ.get("APP_VERSION", "3.6.1")
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -182,7 +182,7 @@ def inject_template_globals():
     lang = get_lang()
     return {
         "current_year": datetime.now().year,
-        "app_version": app.config.get("APP_VERSION", "3.6.0"),
+        "app_version": app.config.get("APP_VERSION", "3.6.1"),
         "current_lang": lang,
         "t": lambda text: t(text, lang),
         "cat_name": lambda name: category_name(name, lang),

--- a/backend/i18n.py
+++ b/backend/i18n.py
@@ -447,6 +447,7 @@ TRANSLATIONS = {
         "Payment method updated.": "Método de pago actualizado.",
         "Payment method deleted.": "Método de pago eliminado.",
         "Name already exists.": "El nombre ya existe.",
+        "An account with this name already exists in the selected bank.": "Ya existe una cuenta con este nombre en el banco seleccionado.",
         "Delete this record?": "¿Eliminar este registro?",
         "No records found.": "No se encontraron registros.",
         "No movements yet": "Aún no hay movimientos",

--- a/backend/migrations/016_payment_method_names_scoped_to_parent.sql
+++ b/backend/migrations/016_payment_method_names_scoped_to_parent.sql
@@ -1,0 +1,10 @@
+ALTER TABLE payment_methods
+DROP CONSTRAINT IF EXISTS payment_methods_name_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_payment_methods_account_name_bank
+ON payment_methods(bank_id, name)
+WHERE kind = 'bank_account';
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_payment_methods_card_name_account
+ON payment_methods(parent_account_id, name)
+WHERE kind = 'card' AND parent_account_id IS NOT NULL;

--- a/backend/migrations/017_card_names_not_unique.sql
+++ b/backend/migrations/017_card_names_not_unique.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS uq_payment_methods_card_name_account;

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -31,6 +31,8 @@ Las migraciones viven en esta carpeta como ficheros SQL planos. El runner de la 
 - `013_loan_type_and_repayment.sql`: agrega tipo de prestamo y total previsto a devolver.
 - `014_data_robustness_constraints.sql`: agrega limites de longitud defensivos para textos principales: conceptos y nombres a 40 caracteres, comentarios y descripciones a 500.
 - `015_cards_linked_to_accounts.sql`: vincula cada tarjeta con su cuenta mediante `parent_account_id`, conservando de forma compatible las tarjetas existentes sin cuenta asignada.
+- `016_payment_method_names_scoped_to_parent.sql`: sustituye la unicidad global por nombres de cuenta unicos dentro de cada banco y, como paso compatible, nombres de tarjeta unicos dentro de cada cuenta.
+- `017_card_names_not_unique.sql`: elimina la restriccion temporal de unicidad de nombres de tarjeta por cuenta; las tarjetas se identifican exclusivamente por `id`.
 
 ## English
 
@@ -63,3 +65,5 @@ Migrations live in this folder as plain SQL files. The app runner (`backend/migr
 - `013_loan_type_and_repayment.sql`: adds loan type and expected total repayment.
 - `014_data_robustness_constraints.sql`: adds defensive length limits for primary text fields: concepts and names to 40 characters, comments and descriptions to 500.
 - `015_cards_linked_to_accounts.sql`: links each card to its account through `parent_account_id`, while compatibly preserving existing cards that do not yet have an assigned account.
+- `016_payment_method_names_scoped_to_parent.sql`: replaces global uniqueness with account names unique within each bank and, as a compatible intermediate step, card names unique within each account.
+- `017_card_names_not_unique.sql`: removes the temporary per-account card-name uniqueness rule; cards are identified exclusively by `id`.

--- a/backend/routes/management.py
+++ b/backend/routes/management.py
@@ -953,6 +953,9 @@ def add_payment_method():
                 if not cur.fetchone():
                     session["management_err"] = t("Select an active bank.")
                     return redirect(url_for("management.payment_methods_section", section="accounts" if kind == "bank_account" else "cards"))
+                if kind == "bank_account" and _account_name_exists(cur, name, bank_id):
+                    session["management_err"] = t(_payment_method_duplicate_message(kind))
+                    return redirect(url_for("management.payment_methods_section", section="accounts" if kind == "bank_account" else "cards"))
                 cur.execute(
                     """
                     INSERT INTO payment_methods (name, kind, bank_id, bank_name, account_ref, is_active, parent_account_id, updated_at)
@@ -973,8 +976,8 @@ def add_payment_method():
             is_active,
         )
         session["management_msg"] = t("Payment method created.")
-    except Exception:
-        session["management_err"] = t("Name already exists.")
+    except psycopg2.IntegrityError:
+        session["management_err"] = t(_payment_method_duplicate_message(kind))
     return redirect(url_for("management.payment_methods_section", section="accounts" if kind == "bank_account" else "cards"))
 
 
@@ -1033,6 +1036,9 @@ def update_payment_method(method_id):
                     if not cur.fetchone():
                         session["management_err"] = t("An account or card cannot be active when its bank is inactive.")
                         return redirect(url_for("management.payment_methods_section", section="accounts" if kind == "bank_account" else "cards"))
+                if kind == "bank_account" and _account_name_exists(cur, name, bank_id, exclude_id=method_id):
+                    session["management_err"] = t(_payment_method_duplicate_message(kind))
+                    return redirect(url_for("management.payment_methods_section", section="accounts" if kind == "bank_account" else "cards"))
                 cur.execute(
                     """
                     UPDATE payment_methods
@@ -1066,8 +1072,8 @@ def update_payment_method(method_id):
             updated,
         )
         session["management_msg"] = t("Payment method updated.")
-    except Exception:
-        session["management_err"] = t("Name already exists.")
+    except psycopg2.IntegrityError:
+        session["management_err"] = t(_payment_method_duplicate_message(kind))
     return redirect(url_for("management.payment_methods_section", section="accounts" if kind == "bank_account" else "cards"))
 
 
@@ -1078,6 +1084,23 @@ def _parse_int_or_none(raw_value):
         return int(raw_value)
     except (TypeError, ValueError):
         return None
+
+
+def _account_name_exists(cur, name, bank_id, exclude_id=None):
+    params = [name, bank_id]
+    exclude_clause = ""
+    if exclude_id is not None:
+        exclude_clause = "AND id<>%s"
+        params.append(exclude_id)
+    cur.execute(
+        f"SELECT 1 FROM payment_methods WHERE name=%s AND kind='bank_account' AND bank_id=%s {exclude_clause} LIMIT 1",
+        tuple(params),
+    )
+    return cur.fetchone() is not None
+
+
+def _payment_method_duplicate_message(kind):
+    return "An account with this name already exists in the selected bank."
 
 
 @management_bp.route("/management/banks/add", methods=["POST"])

--- a/backend/sql/demo_data_management.sql
+++ b/backend/sql/demo_data_management.sql
@@ -46,7 +46,7 @@ BEGIN
         ('Demo - ING Shared Account', 'bank_account', (SELECT id FROM banks WHERE name='ING'), 'ING', 'ES91 0000 0000 0000 0003', TRUE, NULL, NOW()),
         ('Demo - Santander Account', 'bank_account', (SELECT id FROM banks WHERE name='Santander'), 'Santander', 'ES92 0000 0000 0000 0000', TRUE, NULL, NOW()),
         ('Demo - BBVA Account', 'bank_account', (SELECT id FROM banks WHERE name='BBVA'), 'BBVA', 'ES93 0000 0000 0000 0000', TRUE, NULL, NOW())
-    ON CONFLICT (name) DO UPDATE
+    ON CONFLICT (bank_id, name) WHERE kind = 'bank_account' DO UPDATE
     SET
         kind = EXCLUDED.kind,
         bank_id = EXCLUDED.bank_id,
@@ -56,23 +56,28 @@ BEGIN
         parent_account_id = NULL,
         updated_at = NOW();
 
-    INSERT INTO payment_methods (name, kind, bank_id, bank_name, account_ref, is_active, parent_account_id, updated_at)
-    VALUES
-        ('Demo - ING Card - Person 1', 'card', (SELECT id FROM banks WHERE name='ING'), 'ING', '**** 1234', TRUE, (SELECT id FROM payment_methods WHERE name='Demo - ING Account - Person 1'), NOW()),
-        ('Demo - ING Card - Person 2', 'card', (SELECT id FROM banks WHERE name='ING'), 'ING', '**** 5678', TRUE, (SELECT id FROM payment_methods WHERE name='Demo - ING Account - Person 2'), NOW()),
-        ('Demo - ING Shared Card 1', 'card', (SELECT id FROM banks WHERE name='ING'), 'ING', '**** 3456', TRUE, (SELECT id FROM payment_methods WHERE name='Demo - ING Shared Account'), NOW()),
-        ('Demo - ING Shared Card 2', 'card', (SELECT id FROM banks WHERE name='ING'), 'ING', '**** 7890', TRUE, (SELECT id FROM payment_methods WHERE name='Demo - ING Shared Account'), NOW()),
-        ('Demo - Shared Card', 'card', (SELECT id FROM banks WHERE name='Santander'), 'Santander', '**** 9876', TRUE, (SELECT id FROM payment_methods WHERE name='Demo - Santander Account'), NOW()),
-        ('Demo - BBVA Card', 'card', (SELECT id FROM banks WHERE name='BBVA'), 'BBVA', '**** 2468', TRUE, (SELECT id FROM payment_methods WHERE name='Demo - BBVA Account'), NOW())
-    ON CONFLICT (name) DO UPDATE
-    SET
-        kind = EXCLUDED.kind,
-        bank_id = EXCLUDED.bank_id,
-        bank_name = EXCLUDED.bank_name,
-        account_ref = EXCLUDED.account_ref,
-        is_active = EXCLUDED.is_active,
-        parent_account_id = EXCLUDED.parent_account_id,
-        updated_at = NOW();
+    MERGE INTO payment_methods AS target
+    USING (VALUES
+        ('Demo - ING Card - Person 1', 'card', (SELECT id FROM banks WHERE name='ING'), 'ING', '**** 1234', TRUE, (SELECT pm.id FROM payment_methods pm JOIN banks b ON b.id=pm.bank_id WHERE pm.name='Demo - ING Account - Person 1' AND pm.kind='bank_account' AND b.name='ING'), NOW()),
+        ('Demo - ING Card - Person 2', 'card', (SELECT id FROM banks WHERE name='ING'), 'ING', '**** 5678', TRUE, (SELECT pm.id FROM payment_methods pm JOIN banks b ON b.id=pm.bank_id WHERE pm.name='Demo - ING Account - Person 2' AND pm.kind='bank_account' AND b.name='ING'), NOW()),
+        ('Demo - ING Shared Card 1', 'card', (SELECT id FROM banks WHERE name='ING'), 'ING', '**** 3456', TRUE, (SELECT pm.id FROM payment_methods pm JOIN banks b ON b.id=pm.bank_id WHERE pm.name='Demo - ING Shared Account' AND pm.kind='bank_account' AND b.name='ING'), NOW()),
+        ('Demo - ING Shared Card 2', 'card', (SELECT id FROM banks WHERE name='ING'), 'ING', '**** 7890', TRUE, (SELECT pm.id FROM payment_methods pm JOIN banks b ON b.id=pm.bank_id WHERE pm.name='Demo - ING Shared Account' AND pm.kind='bank_account' AND b.name='ING'), NOW()),
+        ('Demo - Shared Card', 'card', (SELECT id FROM banks WHERE name='Santander'), 'Santander', '**** 9876', TRUE, (SELECT pm.id FROM payment_methods pm JOIN banks b ON b.id=pm.bank_id WHERE pm.name='Demo - Santander Account' AND pm.kind='bank_account' AND b.name='Santander'), NOW()),
+        ('Demo - BBVA Card', 'card', (SELECT id FROM banks WHERE name='BBVA'), 'BBVA', '**** 2468', TRUE, (SELECT pm.id FROM payment_methods pm JOIN banks b ON b.id=pm.bank_id WHERE pm.name='Demo - BBVA Account' AND pm.kind='bank_account' AND b.name='BBVA'), NOW())
+    ) AS source(name, kind, bank_id, bank_name, account_ref, is_active, parent_account_id, updated_at)
+    ON target.kind = 'card'
+       AND target.name = source.name
+       AND target.parent_account_id = source.parent_account_id
+    WHEN MATCHED THEN
+        UPDATE SET
+            bank_id = source.bank_id,
+            bank_name = source.bank_name,
+            account_ref = source.account_ref,
+            is_active = source.is_active,
+            updated_at = NOW()
+    WHEN NOT MATCHED THEN
+        INSERT (name, kind, bank_id, bank_name, account_ref, is_active, parent_account_id, updated_at)
+        VALUES (source.name, source.kind, source.bank_id, source.bank_name, source.account_ref, source.is_active, source.parent_account_id, source.updated_at);
 
     SELECT username
     INTO actor_username

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   finance:
-    image: f1nanc3/finance:3.6.0
+    image: f1nanc3/finance:3.6.1
     container_name: finance
     ports:
       - "5000:5000"

--- a/docs/v3.6.1-release/notas-v3.6.1.md
+++ b/docs/v3.6.1-release/notas-v3.6.1.md
@@ -1,0 +1,19 @@
+# Finance v3.6.1 - Nombres de cuentas y tarjetas por contexto
+
+Este hotfix corrige la restricción global que impedía utilizar nombres habituales como `Cuenta compartida` en bancos diferentes.
+
+## Cambios
+
+- Una cuenta solo debe tener un nombre único dentro de su banco.
+- Los nombres de tarjeta pueden repetirse incluso dentro de una misma cuenta porque su identidad depende del `id`.
+- Los nombres de cuenta se pueden reutilizar en bancos diferentes.
+- Los formularios muestran mensajes específicos cuando el duplicado pertenece a la misma entidad padre.
+- Las migraciones `016_payment_method_names_scoped_to_parent.sql` y `017_card_names_not_unique.sql` limitan la unicidad de cuentas a su banco y eliminan la unicidad de nombres de tarjeta sin modificar ni eliminar datos existentes.
+
+## Validación prevista
+
+- Migraciones sobre PostgreSQL aislado.
+- Integridad de altas y ediciones.
+- Rutas, permisos y regresión completa.
+
+No se han creado todavía el commit, la PR, el tag, la release ni las imágenes de esta versión.

--- a/docs/v3.6.1-release/v3.6.1-release-notes.md
+++ b/docs/v3.6.1-release/v3.6.1-release-notes.md
@@ -1,0 +1,19 @@
+# Finance v3.6.1 - Scoped Account and Card Names
+
+This hotfix removes the global restriction that prevented common names such as `Shared Account` from being used at different banks.
+
+## Changes
+
+- An account name only needs to be unique within its bank.
+- Card names may be repeated even within the same account because card identity is based on `id`.
+- Account names can be reused across different banks.
+- Forms show specific messages when a duplicate belongs to the same parent entity.
+- Migrations `016_payment_method_names_scoped_to_parent.sql` and `017_card_names_not_unique.sql` scope account uniqueness to the bank and remove card-name uniqueness without modifying or deleting existing data.
+
+## Planned validation
+
+- Migrations against isolated PostgreSQL.
+- Create and update integrity flows.
+- Routes, permissions, and full regression coverage.
+
+The commit, PR, tag, release, and images for this version have not been created yet.

--- a/tests/test_payment_method_integrity.py
+++ b/tests/test_payment_method_integrity.py
@@ -51,6 +51,58 @@ def test_valid_card_is_created(admin_client, db_query):
     ) == ("card", 1, 2, True)
 
 
+def test_account_name_can_be_reused_in_a_different_bank(admin_client, db_query):
+    response = _post(
+        admin_client,
+        "/payment-methods/add",
+        {"name": "Test Account", "kind": "bank_account", "bank_id": "3", "is_active": "1"},
+    )
+    assert response.status_code == 302
+    assert db_query(
+        "SELECT COUNT(*) FROM payment_methods WHERE name='Test Account' AND kind='bank_account'"
+    )[0] == 2
+
+
+def test_account_name_cannot_be_reused_in_the_same_bank(admin_client, db_query):
+    response = _post(
+        admin_client,
+        "/payment-methods/add",
+        {"name": "Test Account", "kind": "bank_account", "bank_id": "1", "is_active": "1"},
+    )
+    assert response.status_code == 302
+    assert db_query(
+        "SELECT COUNT(*) FROM payment_methods WHERE name='Test Account' AND bank_id=1"
+    )[0] == 1
+
+
+def test_card_name_can_be_reused_in_different_accounts(admin_client, db_query):
+    db_query(
+        """INSERT INTO payment_methods (name, kind, bank_name, bank_id, account_ref, is_active)
+           VALUES ('Second Account', 'bank_account', 'Test Bank', 1, 'ACC-SECOND', TRUE)
+           RETURNING id""",
+        fetch="none",
+    )
+    second_account_id = db_query("SELECT id FROM payment_methods WHERE name='Second Account'")[0]
+    _post(
+        admin_client,
+        "/payment-methods/add",
+        {"name": "Test Card", "kind": "card", "parent_account_id": str(second_account_id), "is_active": "1"},
+    )
+    assert db_query("SELECT COUNT(*) FROM payment_methods WHERE name='Test Card'")[0] == 2
+
+
+def test_card_name_can_be_reused_in_the_same_account(admin_client, db_query):
+    _post(
+        admin_client,
+        "/payment-methods/add",
+        {"name": "Test Card", "kind": "card", "parent_account_id": "2", "is_active": "1"},
+    )
+    assert db_query("SELECT COUNT(*) FROM payment_methods WHERE name='Test Card'")[0] == 2
+    assert db_query(
+        "SELECT COUNT(*) FROM payment_methods WHERE name='Test Card' AND parent_account_id=2"
+    )[0] == 2
+
+
 def test_payment_method_with_movements_cannot_be_deleted(admin_client, db_query):
     _post(admin_client, "/payment-methods/1/delete", {})
     assert db_query("SELECT COUNT(*) FROM payment_methods WHERE id=1")[0] == 1


### PR DESCRIPTION
## Summary

- allow account names to be reused across different banks
- keep account names unique within the same bank
- allow card names to be repeated, including within the same account, because cards are identified by ID
- make the demo-data seed idempotent under the new naming rules
- update version references and bilingual hotfix documentation to 3.6.1

## Root cause

`payment_methods.name` inherited a global unique constraint from the initial schema. That made descriptive names such as `Shared Account` unavailable at a second bank and incorrectly treated card names as identifiers.

## Compatibility

Migrations `016_payment_method_names_scoped_to_parent.sql` and `017_card_names_not_unique.sql` replace global uniqueness without modifying or deleting existing payment-method data.

## Validation

- `git diff --check`
- `python3 -m compileall -q backend`
- payment-method integrity and route contracts: 247 passed
- full suite: 289 passed
- migrations 016 and 017 applied successfully in development
- development image rebuilt and restarted successfully
